### PR TITLE
Basic Auth w/ data store

### DIFF
--- a/backend/sqlite/read/taxiiCollection.sql
+++ b/backend/sqlite/read/taxiiCollection.sql
@@ -4,10 +4,11 @@ select
   c.description,
   uc.can_read,
   uc.can_write,
-  uc.media_types
+  c.media_types
 from
   taxii_collection c
   inner join taxii_user_collection uc
     on c.id = uc.collection_id
 where
-  uc.user_id = ?
+  uc.email = ?
+  and c.id = ?

--- a/backend/sqlite/read/taxiiUser.sql
+++ b/backend/sqlite/read/taxiiUser.sql
@@ -1,0 +1,13 @@
+select
+  tuc.collection_id,
+  tuc.can_read,
+  tuc.can_write
+from
+  taxii_user tu
+  inner join taxii_user_pass tup
+    on tu.email = tup.email
+  inner join taxii_user_collection tuc
+    on tu.email = tuc.email
+where
+  tu.email = ?
+  and tup.pass = ?

--- a/backend/sqlite/schema.sql
+++ b/backend/sqlite/schema.sql
@@ -1,33 +1,89 @@
-drop table if exists taxii_user;
-
-create table taxii_user (
-  id    text not null primary key,
-  email text not null check (email != "")
-);
-
-drop table if exists taxii_user_pass;
-
-create table taxii_user_pass (
-  user_id text not null primary key,
-  pass    text not null check (pass != "")
-);
-
-drop table if exists taxii_user_collection;
-
-create table taxii_user_collection (
-  user_id       text    not null,
-  collection_id text    not null,
-  can_read      integer not null,
-  can_write     integer not null,
-  media_types   text,
-
-  primary key (user_id, collection_id)
-);
-
 drop table if exists taxii_collection;
 
 create table taxii_collection (
   id          text not null primary key,
   title       text,
-  description text
+  description text,
+  media_types text,
+  created_at  text,
+  updated_at  text
 );
+
+  create trigger taxii_collection_ai_created_at after insert on taxii_collection
+    begin
+      update taxii_collection set created_at = datetime('now') where id = new.id;
+      update taxii_collection set updated_at = datetime('now') where id = new.id;
+    end;
+
+  create trigger taxii_collection_au_updated_at after update on taxii_collection
+    begin
+      update taxii_collection set updated_at = datetime('now') where id = new.id;
+    end;
+
+drop table if exists taxii_user;
+
+create table taxii_user (
+  email      text not null primary key,
+  created_at text,
+  updated_at text
+);
+
+  create trigger taxii_user_ai_created_at after insert on taxii_user
+    begin
+      update taxii_user set created_at = datetime('now') where email = new.email;
+      update taxii_user set updated_at = datetime('now') where email = new.email;
+    end;
+
+  create trigger taxii_user_bi_email before insert on taxii_user
+    begin
+      select case when new.email not like '%_@__%.__%' then raise(abort, 'Invalid email address') end;
+    end;
+
+  create trigger taxii_user_au_updated_at after update on taxii_user
+    begin
+      update taxii_user set updated_at = datetime('now') where email = new.email;
+    end;
+
+drop table if exists taxii_user_collection;
+
+create table taxii_user_collection (
+  email         text    not null,
+  collection_id text    not null,
+  can_read      integer not null,
+  can_write     integer not null,
+  created_at    text,
+  updated_at    text,
+
+  primary key (email, collection_id)
+);
+
+  create trigger taxii_user_collection_ai_created_at after insert on taxii_user_collection
+    begin
+      update taxii_user_collection set created_at = datetime('now') where email = new.email;
+      update taxii_user_collection set updated_at = datetime('now') where email = new.email;
+    end;
+
+  create trigger taxii_user_collection_au_updated_at after update on taxii_user_collection
+    begin
+      update taxii_user_collection set updated_at = datetime('now') where email = new.email;
+    end;
+
+drop table if exists taxii_user_pass;
+
+create table taxii_user_pass (
+  email      text not null primary key,
+  pass       text not null check (pass != ""),
+  created_at text,
+  updated_at text
+);
+
+  create trigger taxii_user_pass_ai_created_at after insert on taxii_user_pass
+    begin
+      update taxii_user_pass set created_at = datetime('now') where email = new.email;
+      update taxii_user_pass set updated_at = datetime('now') where email = new.email;
+    end;
+
+  create trigger taxii_user_pass_au_updated_at after update on taxii_user_pass
+    begin
+      update taxii_user_pass set updated_at = datetime('now') where email = new.email;
+    end;

--- a/backend_test.go
+++ b/backend_test.go
@@ -115,7 +115,6 @@ func TestSQLiteRead(t *testing.T) {
 
 	// create a collection record and add a user to access it
 	tuid := uuid.Must(uuid.NewV4())
-	email := "test@test.com"
 	_, err = s.db.Exec(`insert into taxii_collection (id, title, description, media_types)
 	                    values ("` + tuid.String() + `", "a title", "a description", "")`)
 	if err != nil {
@@ -123,7 +122,7 @@ func TestSQLiteRead(t *testing.T) {
 	}
 
 	_, err = s.db.Exec(`insert into taxii_user_collection (email, collection_id, can_read, can_write)
-	                    values ('` + email + `', "` + tuid.String() + `", 1, 1)`)
+	                    values ('` + testUser + `', "` + tuid.String() + `", 1, 1)`)
 	if err != nil {
 		t.Fatal("DB Err:", err)
 	}
@@ -131,7 +130,7 @@ func TestSQLiteRead(t *testing.T) {
 	// buffered channel
 	results := make(chan interface{}, 10)
 	query, _ := s.parse("read", "taxiiCollection")
-	go s.read(query, "taxiiCollection", []interface{}{email, tuid.String()}, results)
+	go s.read(query, "taxiiCollection", []interface{}{testUser, tuid.String()}, results)
 
 	for r := range results {
 		switch r := r.(type) {
@@ -147,7 +146,7 @@ func TestSQLiteRead(t *testing.T) {
 
 	// unbuffered channel
 	results = make(chan interface{})
-	go s.read(query, "taxiiCollection", []interface{}{email, tuid.String()}, results)
+	go s.read(query, "taxiiCollection", []interface{}{testUser, tuid.String()}, results)
 
 	for r := range results {
 		switch r := r.(type) {

--- a/backend_test.go
+++ b/backend_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"io/ioutil"
 	"strconv"
 	"testing"
@@ -100,7 +101,7 @@ func TestSQLiteParseInvalid(t *testing.T) {
 	}
 }
 
-/* sqlite reader interface */
+/* sqlite reader functions */
 
 func TestSQLiteRead(t *testing.T) {
 	c := cabbyConfig{}.parse(configPath)
@@ -114,12 +115,15 @@ func TestSQLiteRead(t *testing.T) {
 
 	// create a collection record and add a user to access it
 	tuid := uuid.Must(uuid.NewV4())
-	_, err = s.db.Exec(`insert into taxii_collection values ("` + tuid.String() + `", "a title", "a description")`)
+	email := "test@test.com"
+	_, err = s.db.Exec(`insert into taxii_collection (id, title, description, media_types)
+	                    values ("` + tuid.String() + `", "a title", "a description", "")`)
 	if err != nil {
 		t.Fatal("DB Err:", err)
 	}
 
-	_, err = s.db.Exec(`insert into taxii_user_collection values ("user1", "` + tuid.String() + `", 1, 1, "")`)
+	_, err = s.db.Exec(`insert into taxii_user_collection (email, collection_id, can_read, can_write)
+	                    values ('` + email + `', "` + tuid.String() + `", 1, 1)`)
 	if err != nil {
 		t.Fatal("DB Err:", err)
 	}
@@ -127,7 +131,7 @@ func TestSQLiteRead(t *testing.T) {
 	// buffered channel
 	results := make(chan interface{}, 10)
 	query, _ := s.parse("read", "taxiiCollection")
-	go s.read(query, "taxiiCollection", []interface{}{"user1"}, results)
+	go s.read(query, "taxiiCollection", []interface{}{email, tuid.String()}, results)
 
 	for r := range results {
 		switch r := r.(type) {
@@ -143,7 +147,7 @@ func TestSQLiteRead(t *testing.T) {
 
 	// unbuffered channel
 	results = make(chan interface{})
-	go s.read(query, "taxiiCollection", []interface{}{"user1"}, results)
+	go s.read(query, "taxiiCollection", []interface{}{email, tuid.String()}, results)
 
 	for r := range results {
 		switch r := r.(type) {
@@ -192,7 +196,8 @@ Loop:
 	setupSQLite() // reset state
 }
 
-func TestSQLiteReadCollectionScanError(t *testing.T) {
+// new readX functions get tested here
+func TestSQLiteReadScanError(t *testing.T) {
 	c := cabbyConfig{}.parse(configPath)
 	c.DataStore["path"] = testDB
 
@@ -202,24 +207,35 @@ func TestSQLiteReadCollectionScanError(t *testing.T) {
 	}
 	defer s.disconnect()
 
-	rows, err := s.db.Query(`select "fail"`)
-	if err != nil {
-		t.Fatal(err)
+	type readFunction func(*sql.Rows, chan interface{})
+
+	tests := []struct {
+		fn readFunction
+	}{
+		{s.readCollection},
+		{s.readUser},
 	}
 
-	results := make(chan interface{})
-	go s.readCollection(rows, results)
-
-	for r := range results {
-		switch r := r.(type) {
-		case error:
-			logError.Println(r)
-			err = r
+	for _, rf := range tests {
+		rows, err := s.db.Query(`select "fail"`)
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
 
-	if err == nil {
-		t.Error("Expected error")
+		results := make(chan interface{})
+		go rf.fn(rows, results)
+
+		for r := range results {
+			switch r := r.(type) {
+			case error:
+				logError.Println(r)
+				err = r
+			}
+		}
+
+		if err == nil {
+			t.Error("Expected error")
+		}
 	}
 }
 

--- a/cabby_test.go
+++ b/cabby_test.go
@@ -15,8 +15,8 @@ import (
 const (
 	discoveryURL = "https://localhost:1234/taxii"
 	apiRootURL   = "https://localhost:1234/api_root"
-	testUser     = "pladdy"
-	testPass     = "pants"
+	testUser     = "test@cabby.com"
+	testPass     = "test"
 )
 
 /* helpers */
@@ -40,6 +40,14 @@ func attemptRequest(c *http.Client, r *http.Request) (*http.Response, error) {
 }
 
 func get(u string) string {
+	renameFile(configPath, configPath+".testing")
+	renameFile("test/config/testing_config.json", configPath)
+
+	defer func() {
+		renameFile(configPath, "test/config/testing_config.json")
+		renameFile(configPath+".testing", configPath)
+	}()
+
 	c := cabbyConfig{}.parse(configPath)
 	server := newCabby(c)
 	go func() {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -31,12 +31,20 @@ func handlerTest(h handlerFn, m, u string) (int, string) {
 /* auth tests */
 
 func TestBasicAuth(t *testing.T) {
+	renameFile(configPath, configPath+".testing")
+	renameFile("test/config/testing_config.json", configPath)
+
+	defer func() {
+		renameFile(configPath, "test/config/testing_config.json")
+		renameFile(configPath+".testing", configPath)
+	}()
+
 	tests := []struct {
 		user     string
 		pass     string
 		expected int
 	}{
-		{"pladdy", "pants", 200},
+		{testUser, testPass, 200},
 		{"simon", "says", 401},
 	}
 
@@ -58,6 +66,14 @@ func TestBasicAuth(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	renameFile(configPath, configPath+".testing")
+	renameFile("test/config/testing_config.json", configPath)
+
+	defer func() {
+		renameFile(configPath, "test/config/testing_config.json")
+		renameFile(configPath+".testing", configPath)
+	}()
+
 	tests := []struct {
 		user     string
 		pass     string

--- a/models.go
+++ b/models.go
@@ -1,13 +1,26 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 
 	uuid "github.com/satori/go.uuid"
 )
 
 const minBuffer = 10
+
+/* helpers */
+
+func processReadError(err error, results chan interface{}) {
+	logError.Println(err)
+	results <- err
+	close(results)
+}
+
+/* models and methods */
 
 type cabbyConfig struct {
 	Host       string
@@ -74,11 +87,17 @@ type taxiiAPIRoot struct {
 
 type taxiiCollection struct {
 	ID          uuid.UUID `json:"id"`
-	Title       string    `json:"title"`
-	Description string    `json:"description,omitempty"`
 	CanRead     bool      `json:"can_read"`
 	CanWrite    bool      `json:"can_write"`
+	Title       string    `json:"title"`
+	Description string    `json:"description,omitempty"`
 	MediaTypes  []string  `json:"media_types,omitempty"`
+}
+
+type taxiiCollectionAccess struct {
+	ID       uuid.UUID `json:"id"`
+	CanRead  bool      `json:"can_read"`
+	CanWrite bool      `json:"can_write"`
 }
 
 func newTaxiiCollection(uid ...string) (taxiiCollection, error) {
@@ -100,13 +119,11 @@ func newUUID(arg ...string) (uuid.UUID, error) {
 func (c taxiiCollection) create(config cabbyConfig) error {
 	t, err := newTaxiiStorer(config)
 	if err != nil {
-		logError.Println(err)
 		return err
 	}
 
 	query, err := t.parse("create", "taxiiCollection")
 	if err != nil {
-		logError.Println(err)
 		return err
 	}
 
@@ -128,13 +145,13 @@ func (c taxiiCollection) create(config cabbyConfig) error {
 func (c taxiiCollection) read(config cabbyConfig, u string, results chan interface{}) {
 	t, err := newTaxiiStorer(config)
 	if err != nil {
-		results <- err
+		processReadError(err, results)
 		return
 	}
 
 	query, err := t.parse("read", "taxiiCollection")
 	if err != nil {
-		results <- err
+		processReadError(err, results)
 		return
 	}
 
@@ -161,14 +178,58 @@ type taxiiError struct {
 }
 
 type taxiiStatus struct {
-	ID               string   `json:"id"`
-	Status           string   `json:"status"`
-	RequestTimestamp string   `json:"request_timestamp"`
-	TotalCount       int64    `json:"total_count"`
-	SuccessCount     int64    `json:"success_count"`
-	Successes        []string `json:"successes"`
-	FailureCount     int64    `json:"failure_count"`
-	Failures         []string `json:"failures"`
-	PendingCount     int64    `json:"pending_count"`
-	Pendings         []string `json:"pendings"`
+	ID               uuid.UUID `json:"id"`
+	Status           string    `json:"status"`
+	RequestTimestamp string    `json:"request_timestamp"`
+	TotalCount       int64     `json:"total_count"`
+	SuccessCount     int64     `json:"success_count"`
+	Successes        []string  `json:"successes"`
+	FailureCount     int64     `json:"failure_count"`
+	Failures         []string  `json:"failures"`
+	PendingCount     int64     `json:"pending_count"`
+	Pendings         []string  `json:"pendings"`
+}
+
+type taxiiUser struct {
+	Email            string
+	CollectionAccess map[uuid.UUID]taxiiCollectionAccess
+}
+
+func newTaxiiUser(config cabbyConfig, u, p string) (taxiiUser, error) {
+	tu := taxiiUser{Email: u, CollectionAccess: make(map[uuid.UUID]taxiiCollectionAccess)}
+	results := make(chan interface{}, minBuffer)
+	var err error
+
+	go tu.read(config, fmt.Sprintf("%x", sha256.Sum256([]byte(p))), results)
+
+	for r := range results {
+		switch r.(type) {
+		case error:
+			return tu, r.(error)
+		}
+		a := r.(taxiiCollectionAccess)
+		tu.CollectionAccess[a.ID] = a
+	}
+
+	if len(tu.CollectionAccess) <= 0 {
+		err = errors.New("No access to any collections")
+	}
+	return tu, err
+}
+
+func (tu taxiiUser) read(config cabbyConfig, pass string, results chan interface{}) {
+	t, err := newTaxiiStorer(config)
+	if err != nil {
+		processReadError(err, results)
+		return
+	}
+
+	query, err := t.parse("read", "taxiiUser")
+	if err != nil {
+		processReadError(err, results)
+		return
+	}
+
+	args := []interface{}{tu.Email, pass}
+	t.read(query, "taxiiUser", args, results)
 }


### PR DESCRIPTION
#### What's new
- changed basic auth to use data store
- updated schema for sqlite
- refactored/recoded some backend functions

#### How to test
`make test`

#### TODO (in future PRs):
- add get collections endpoint
- switch to using a `context` for config; once a handler is called, it can read config but then passes config in context to model/backend