### PR TITLE
require valid accept header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,4 @@ test:
 	go test -v -cover ./...
 
 test_failures:
-	go test -v ./... 2>&1 | grep FAIL
+	go test -v ./... 2>&1 | grep -A 1 FAIL

--- a/cabby.go
+++ b/cabby.go
@@ -9,13 +9,7 @@ import (
 	"strconv"
 )
 
-const (
-	configPath         = "config/cabby.json"
-	stixContentType20  = "application/vnd.oasis.stix+json; version=2.0"
-	stixContentType    = "application/vnd.oasis.stix+json"
-	taxiiContentType20 = "application/vnd.oasis.taxii+json; version=2.0"
-	taxiiContentType   = "application/vnd.oasis.taxii+json"
-)
+const configPath = "config/cabby.json"
 
 var (
 	info = log.New(os.Stderr, "INFO: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile|log.LUTC)
@@ -43,10 +37,10 @@ func registerAPIRoot(apiRoot string, h *http.ServeMux) {
 
 	path := "/" + u.String() + "/"
 	info.Println("Registering handler for", path+"collections/")
-	h.HandleFunc(path+"collections/", handleTaxiiCollections)
+	h.HandleFunc(path+"collections/", requireAcceptTaxii(handleTaxiiCollections))
 
 	info.Println("Registering handler for", path)
-	h.HandleFunc(path, handleTaxiiAPIRoot)
+	h.HandleFunc(path, requireAcceptTaxii(handleTaxiiAPIRoot))
 }
 
 func setupHandler() (*http.ServeMux, error) {
@@ -62,8 +56,8 @@ func setupHandler() (*http.ServeMux, error) {
 		registerAPIRoot(apiRoot, handler)
 	}
 
-	handler.HandleFunc("/taxii/", handleTaxiiDiscovery)
-	handler.HandleFunc("/", handleUndefinedRequest)
+	handler.HandleFunc("/taxii/", requireAcceptTaxii(handleTaxiiDiscovery))
+	handler.HandleFunc("/", requireAcceptTaxii(handleUndefinedRequest))
 
 	return handler, err
 }

--- a/cabby_test.go
+++ b/cabby_test.go
@@ -40,6 +40,7 @@ func requestWithBasicAuth(u string) *http.Request {
 	if err != nil {
 		fail.Fatal(err)
 	}
+	req.Header.Add("Accept", taxiiContentType)
 	req.SetBasicAuth(testUser, testPass)
 	return req
 }
@@ -121,6 +122,7 @@ func TestBasicAuth(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		req.Header.Add("Accept", taxiiContentType)
 		req.SetBasicAuth(test.user, test.pass)
 
 		res, _ := requestFromTestServer(req)

--- a/handlers.go
+++ b/handlers.go
@@ -26,11 +26,6 @@ const (
 	userCollections key = 1
 )
 
-var acceptTypes = []string{
-	taxiiContentType,
-	taxiiContentType20,
-}
-
 /* auth functions */
 
 func addTaxiiUserToRequest(tu taxiiUser, r *http.Request) *http.Request {

--- a/handlers.go
+++ b/handlers.go
@@ -15,10 +15,21 @@ import (
 type key int
 
 const (
-	sixMonthsOfSeconds     = "63072000"
-	userName           key = 0
-	userCollections    key = 1
+	sixMonthsOfSeconds = "63072000"
+
+	stixContentType20  = "application/vnd.oasis.stix+json; version=2.0"
+	stixContentType    = "application/vnd.oasis.stix+json"
+	taxiiContentType20 = "application/vnd.oasis.taxii+json; version=2.0"
+	taxiiContentType   = "application/vnd.oasis.taxii+json"
+
+	userName        key = 0
+	userCollections key = 1
 )
+
+var acceptTypes = []string{
+	taxiiContentType,
+	taxiiContentType20,
+}
 
 /* auth functions */
 
@@ -50,6 +61,30 @@ func hsts(w http.ResponseWriter) http.ResponseWriter {
 	return w
 }
 
+func splitAcceptHeader(h string) (string, string) {
+	parts := strings.Split(h, ";")
+	first := parts[0]
+
+	var second string
+	if len(parts) > 1 {
+		second = parts[1]
+	}
+
+	return first, second
+}
+
+func requireAcceptTaxii(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		contentType, _ := splitAcceptHeader(r.Header.Get("Accept"))
+
+		if contentType != taxiiContentType {
+			unsupportedMediaType(w, fmt.Errorf("Invalid 'Accept' Header: %v", contentType))
+			return
+		}
+		h(w, r)
+	}
+}
+
 func validateUser(u, p string) (taxiiUser, bool) {
 	tu, err := newTaxiiUser(u, p)
 	if err != nil {
@@ -71,29 +106,37 @@ func errorStatus(w http.ResponseWriter, title string, err error, status int) {
 	http.Error(w, resourceToJSON(te), status)
 }
 
-func unauthorized(w http.ResponseWriter, err error) {
-	w.Header().Set("WWW-Authenticate", "Basic realm=TAXII 2.0")
-	errorStatus(w, "Unauthorized", err, http.StatusUnauthorized)
-}
-
 func badRequest(w http.ResponseWriter, err error) {
 	errorStatus(w, "Bad Request", err, http.StatusBadRequest)
+}
+
+func methodNotAllowed(w http.ResponseWriter, err error) {
+	errorStatus(w, "Method Not Allowed", err, http.StatusMethodNotAllowed)
 }
 
 func resourceNotFound(w http.ResponseWriter, err error) {
 	errorStatus(w, "Resource not found", err, http.StatusNotFound)
 }
 
-func recoverFromPanic(w http.ResponseWriter) {
-	if r := recover(); r != nil {
-		resourceNotFound(w, errors.New("Resource not found"))
-	}
+func unauthorized(w http.ResponseWriter, err error) {
+	w.Header().Set("WWW-Authenticate", "Basic realm=TAXII 2.0")
+	errorStatus(w, "Unauthorized", err, http.StatusUnauthorized)
+}
+
+func unsupportedMediaType(w http.ResponseWriter, err error) {
+	errorStatus(w, "Unsupported Media Type", err, http.StatusUnsupportedMediaType)
 }
 
 /* catch undefined route */
 
 func handleUndefinedRequest(w http.ResponseWriter, r *http.Request) {
 	resourceNotFound(w, fmt.Errorf("Undefined request: %v", r.URL))
+}
+
+func recoverFromPanic(w http.ResponseWriter) {
+	if r := recover(); r != nil {
+		resourceNotFound(w, errors.New("Resource not found"))
+	}
 }
 
 /* helpers */

--- a/taxii_collections.go
+++ b/taxii_collections.go
@@ -17,12 +17,12 @@ func handleTaxiiCollections(w http.ResponseWriter, r *http.Request) {
 	defer recoverFromPanic(w)
 
 	switch r.Method {
-	case "GET":
+	case http.MethodGet:
 		handleGetTaxiiCollections(w, r)
-	case "POST":
+	case http.MethodPost:
 		handlePostTaxiiCollection(w, r)
 	default:
-		badRequest(w, errors.New("HTTP Method "+r.Method+" Unrecognized"))
+		methodNotAllowed(w, errors.New("HTTP Method "+r.Method+" Unrecognized"))
 		return
 	}
 }
@@ -148,7 +148,7 @@ func newTaxiiID(arg ...string) (taxiiID, error) {
 
 func (ti *taxiiID) isEmpty() bool {
 	empty := &taxiiID{}
-	if ti == empty {
+	if ti.String() == empty.String() {
 		return true
 	}
 	return false

--- a/taxii_collections_test.go
+++ b/taxii_collections_test.go
@@ -96,13 +96,13 @@ func TestHandlePostTaxiiCollectionsBadID(t *testing.T) {
 	}
 }
 
-func TestHandlePostTaxiiCollectionsBadParse(t *testing.T) {
+func TestHandlePostTaxiiCollectionsMethod(t *testing.T) {
 	tests := []struct {
 		method   string
 		expected int
 	}{
 		{"POST", 400},
-		{"CUSTOM", 400},
+		{"CUSTOM", 405},
 	}
 
 	for _, test := range tests {
@@ -679,7 +679,12 @@ func TestTaxiiIDIsEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if id.isEmpty() != false {
-		t.Error("Expected to be empty")
+	if id.isEmpty() == true {
+		t.Error("Expected to NOT be empty")
+	}
+
+	emptyID := taxiiID{}
+	if emptyID.isEmpty() == false {
+		t.Error("Expected ID to be empty")
 	}
 }


### PR DESCRIPTION
#### What's new
- use decorator on handlers that require taxii accept header
- add tests
- update make file to get a line after failures

#### How to test
`make test`