### PR TITLE
cabbyConfig -> Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ To run all tests: `make test`
 "Helper" functions are in `test_helper_test.go`.  The goal with this file was to put repetitive code that make the
 tests verbose into a DRY'er format.
 
-## Run
-`make run`
-
 ## Configuration
 The `make` task will generate certs and a default config file.  Edit the `config/cabby.json` file to adjust things like
 - discovery
@@ -58,7 +55,7 @@ insert into taxii_discovery (title, description, contact, default_url) values(
   "a local taxii 2 server",
   "this is a test taxii2 server written in golang",
   "github.com/pladdy",
-  "https:/localhost/taxii/"
+  "https://localhost/taxii/"
 )'
 
 # set up api root
@@ -75,7 +72,6 @@ insert into taxii_api_root (id, api_root_path, title, description, versions, max
 
 In another terminal, run a server:
 ```sh
-make
 make run
 ```
 

--- a/backend_sqlite.go
+++ b/backend_sqlite.go
@@ -156,7 +156,7 @@ func (s *sqliteDB) readDiscovery(rows *sql.Rows) (interface{}, error) {
 			return td, err
 		}
 		if apiRoot != "No API Roots defined" {
-			apiRoots = append(apiRoots, td.Default+apiRoot)
+			apiRoots = append(apiRoots, apiRoot)
 		}
 	}
 

--- a/cabby.go
+++ b/cabby.go
@@ -13,7 +13,7 @@ const defaultConfig = "config/cabby.json"
 func newCabby(configPath string) (*http.Server, error) {
 	var server http.Server
 
-	config = cabbyConfig{}.parse(configPath)
+	config = Config{}.parse(configPath)
 
 	ts, err := newTaxiiStorer(config.DataStore["name"], config.DataStore["path"])
 	if err != nil {
@@ -38,7 +38,7 @@ func registerAPIRoot(ts taxiiStorer, rootPath string, h *http.ServeMux) {
 func registerRoute(sm *http.ServeMux, path string, h http.HandlerFunc) {
 	log.WithFields(log.Fields{
 		"path": path,
-	}).Info("Registering handler for")
+	}).Info("Registering handler")
 
 	sm.HandleFunc(path,
 		withRequestLogging(
@@ -59,7 +59,7 @@ func setupHandler(ts taxiiStorer) (*http.ServeMux, error) {
 		registerAPIRoot(ts, rootPath, handler)
 	}
 
-	registerRoute(handler, "/taxii/", handleTaxiiDiscovery(ts))
+	registerRoute(handler, "/taxii/", handleTaxiiDiscovery(ts, config.Port))
 	registerRoute(handler, "/", handleUndefinedRequest)
 	return handler, err
 }
@@ -69,7 +69,7 @@ func setupServer(ts taxiiStorer, h http.Handler) *http.Server {
 	port := strconv.Itoa(config.Port)
 	log.WithFields(log.Fields{
 		"port": port,
-	}).Info("Configuring port to listen on")
+	}).Info("Server port configured")
 
 	return &http.Server{
 		Addr:         ":" + port,

--- a/cabby_test.go
+++ b/cabby_test.go
@@ -140,6 +140,7 @@ func TestMain(t *testing.T) {
 	}()
 
 	mainTestConfigPort := "1235"
+
 	req := requestWithBasicAuth(strings.Replace(discoveryURL, "1234", mainTestConfigPort, 1))
 	res, _ := attemptRequest(tlsClient(), req)
 	defer res.Body.Close()
@@ -153,7 +154,9 @@ func TestMain(t *testing.T) {
 	}
 
 	expected := testDiscovery
-	expected.Default = insertPort(expected.Default)
+
+	expected.Default = ""
+	result.Default = ""
 
 	if result.Default != expected.Default {
 		t.Error("Got:", result.Default, "Expected:", expected.Default)

--- a/config.go
+++ b/config.go
@@ -7,9 +7,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var config cabbyConfig
+var config Config
 
-type cabbyConfig struct {
+type Config struct {
 	Host      string
 	Port      int
 	SSLCert   string            `json:"ssl_cert"`
@@ -18,7 +18,7 @@ type cabbyConfig struct {
 }
 
 // given a path to a config file parse it from json
-func (c cabbyConfig) parse(file string) (pc cabbyConfig) {
+func (c Config) parse(file string) (pc Config) {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/config_test.go
+++ b/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
-	config = cabbyConfig{}.parse("config/cabby.example.json")
+	config = Config{}.parse("config/cabby.example.json")
 	defer loadTestConfig()
 
 	if config.Host != "localhost" {
@@ -27,7 +27,7 @@ func TestParseConfigNotFound(t *testing.T) {
 		}
 	}()
 
-	_ = cabbyConfig{}.parse("foo/bar")
+	_ = Config{}.parse("foo/bar")
 	t.Error("Failed to panic with an unknown resource")
 }
 
@@ -42,6 +42,6 @@ func TestParseConfigInvalidJSON(t *testing.T) {
 	}()
 
 	_ = ioutil.WriteFile(invalidJSON, []byte("invalid"), 0644)
-	_ = cabbyConfig{}.parse(invalidJSON)
+	_ = Config{}.parse(invalidJSON)
 	t.Error("Failed to panic with an unknown resource")
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 )
 
@@ -92,7 +91,7 @@ func TestWithLoggingUnauthorized(t *testing.T) {
 	req := httptest.NewRequest("GET", discoveryURL, nil)
 	// omit adding a user to the context
 	res := httptest.NewRecorder()
-	withRequestLogging(handleTaxiiDiscovery(ts))(res, req)
+	withRequestLogging(handleTaxiiDiscovery(ts, config.Port))(res, req)
 
 	if res.Code != http.StatusUnauthorized {
 		t.Error("Got:", res.Code, "Expected: unauthorized")
@@ -110,7 +109,7 @@ func TestHeaders(t *testing.T) {
 	ts := getStorer()
 	defer ts.disconnect()
 
-	h := handleTaxiiDiscovery(ts)
+	h := handleTaxiiDiscovery(ts, config.Port)
 	s := httptest.NewServer(http.HandlerFunc(h))
 	defer s.Close()
 
@@ -185,24 +184,5 @@ func TestResourceToJSONFail(t *testing.T) {
 
 	if recovered != true {
 		t.Error("Got:", result, "Expected: 'recovered' to be true")
-	}
-}
-
-func TestUrlWithNoPort(t *testing.T) {
-	tests := []struct {
-		host     string
-		expected string
-	}{
-		{"https://localhost:1234/api_root", "https://localhost/api_root"},
-		{"https://localhost/api_root", "https://localhost/api_root"},
-		{"/api_root", "https://localhost/api_root"},
-	}
-
-	for _, test := range tests {
-		u, _ := url.Parse(test.host)
-		result := urlWithNoPort(u)
-		if result != test.expected {
-			t.Error("Got:", result, "Expected:", test.expected)
-		}
 	}
 }

--- a/taxii_collection.go
+++ b/taxii_collection.go
@@ -34,7 +34,7 @@ func handleGetTaxiiCollections(ts taxiiStorer, w http.ResponseWriter, r *http.Re
 
 	user, ok := r.Context().Value(userName).(string)
 	if !ok {
-		badRequest(w, errors.New("Invalid user specified"))
+		unauthorized(w, errors.New("Invalid user specified"))
 		return
 	}
 

--- a/taxii_collection_test.go
+++ b/taxii_collection_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -245,16 +246,11 @@ func TestHandleTaxiiCollectionsGetInvalidUser(t *testing.T) {
 	res := httptest.NewRecorder()
 	h := handleTaxiiCollections(ts)
 	h(res, req)
-	b, _ := ioutil.ReadAll(res.Body)
 
-	status, result := res.Code, string(b)
-	expected := `{"title":"Bad Request","description":"Invalid user specified","http_status":"400"}` + "\n"
+	status := res.Code
 
-	if status != 400 {
-		t.Error("Got:", status, "Expected:", 400)
-	}
-	if result != expected {
-		t.Error("Got:", result, "Expected:", expected)
+	if status != http.StatusUnauthorized {
+		t.Error("Got:", status, "Expected:", http.StatusUnauthorized)
 	}
 }
 

--- a/taxii_discovery_test.go
+++ b/taxii_discovery_test.go
@@ -10,7 +10,7 @@ func TestHandleTaxiiDiscovery(t *testing.T) {
 	ts := getStorer()
 	defer ts.disconnect()
 
-	status, result := handlerTest(handleTaxiiDiscovery(ts), "GET", discoveryURL, nil)
+	status, result := handlerTest(handleTaxiiDiscovery(ts, config.Port), "GET", discoveryURL, nil)
 
 	if status != 200 {
 		t.Error("Got:", status, "Expected:", 200)
@@ -45,7 +45,7 @@ func TestHandleTaxiiDiscoveryNoDiscovery(t *testing.T) {
 
 	req := httptest.NewRequest("GET", discoveryURL, nil)
 	res := httptest.NewRecorder()
-	h := handleTaxiiDiscovery(ts)
+	h := handleTaxiiDiscovery(ts, config.Port)
 	h(res, req)
 
 	if res.Code != 404 {
@@ -71,7 +71,7 @@ func TestHandleTaxiiDiscoveryError(t *testing.T) {
 
 	req := httptest.NewRequest("GET", discoveryURL, nil)
 	res := httptest.NewRecorder()
-	h := handleTaxiiDiscovery(ts)
+	h := handleTaxiiDiscovery(ts, config.Port)
 	h(res, req)
 
 	if res.Code != 400 {
@@ -91,5 +91,41 @@ func TestTaxiiDiscoveryFailParse(t *testing.T) {
 
 	if err == nil {
 		t.Error("Expected a taxiiStorer error")
+	}
+}
+
+func TestInsertPort(t *testing.T) {
+	tests := []struct {
+		url      string
+		port     int
+		expected string
+	}{
+		{"http://test.com/foo", 1234, "http://test.com:1234/foo"},
+		{"http://test.com", 1234, "http://test.com:1234"},
+	}
+
+	for _, test := range tests {
+		result := insertPort(test.url, test.port)
+		if result != test.expected {
+			t.Error("Got:", result, "Expected:", test.expected)
+		}
+	}
+}
+
+func TestSwapPath(t *testing.T) {
+	tests := []struct {
+		url      string
+		path     string
+		expected string
+	}{
+		{"http://test.com/foo", "baz", "http://test.com/baz"},
+		{"http://test.com", "foo", "http://test.com/foo"},
+	}
+
+	for _, test := range tests {
+		result := swapPath(test.url, test.path)
+		if result != test.expected {
+			t.Error("Got:", result, "Expected:", test.expected)
+		}
 	}
 }

--- a/taxii_user_test.go
+++ b/taxii_user_test.go
@@ -87,7 +87,7 @@ func TestNewTaxiiUserFail(t *testing.T) {
 	ts := getStorer()
 	defer ts.disconnect()
 
-	config = cabbyConfig{}
+	config = Config{}
 
 	_, err := newTaxiiUser(ts, "test@test.fail", "nopass")
 	if err == nil {

--- a/test_helper_test.go
+++ b/test_helper_test.go
@@ -94,7 +94,7 @@ func getSQLiteDB() *sqliteDB {
 }
 
 func loadTestConfig() {
-	config = cabbyConfig{}.parse(testConfig)
+	config = Config{}.parse(testConfig)
 }
 
 func renameFile(from, to string) {


### PR DESCRIPTION
#### What's new
- cabbyConfig -> Config (cabby is redundant)
- fix api roots so they get the configured port

#### How to test
`make test`