### PR TITLE
Status bug

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,10 @@ Handle migrations with a tool?
 
 Should we open port 443 in vagrant? https://help.ubuntu.com/community/UFW#UFW_-_Uncomplicated_Firewall
 
+#### batch writing
+- errors can happen in more than 1 scenario, which can inflate the failure counts which the status service uses to figure
+  out what was successful vs not...
+  
 #### Admin section
 What about these use cases?  Right now, data is left in place...
   - if i delete a user, should i delete their collection associations?

--- a/http/objects.go
+++ b/http/objects.go
@@ -170,6 +170,7 @@ func bundleFromBytes(b []byte) (stones.Bundle, error) {
 
 	err := json.Unmarshal(b, &bundle)
 	if err != nil {
+		log.WithFields(log.Fields{"bundle": string(b)}).Error("Unable to unmarshal bundle")
 		return bundle, fmt.Errorf("Unable to convert json to bundle, error: %v", err)
 	}
 

--- a/http/objects_test.go
+++ b/http/objects_test.go
@@ -19,6 +19,23 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func TestBundleFromBytes(t *testing.T) {
+	bundleFile, err := os.Open("testdata/malware_bundle.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawBundle, err := ioutil.ReadAll(bundleFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = bundleFromBytes(rawBundle)
+	if err != nil {
+		t.Error("Error unexpected:", err)
+	}
+}
+
 func TestBundleFromBytesUnmarshalFail(t *testing.T) {
 	b, err := bundleFromBytes([]byte(`{"foo": "bar"`))
 	if err == nil {

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -113,6 +113,7 @@ func (s *DataStore) batchWrite(query string, toWrite chan interface{}, errs chan
 
 		err := s.execute(stmt, args...)
 		if err != nil {
+			log.WithFields(log.Fields{"sql": query, "error": err}).Error("Error after call to 'execute'")
 			errs <- err
 			continue
 		}
@@ -121,12 +122,14 @@ func (s *DataStore) batchWrite(query string, toWrite chan interface{}, errs chan
 		if i >= maxWritesPerBatch {
 			err := tx.Commit() // on commit a statement is closed, create a new transaction for next batch
 			if err != nil {
+				log.WithFields(log.Fields{"sql": query, "error": err}).Error("Error after call to 'Commit'")
 				errs <- err
 				return
 			}
 
 			tx, stmt, err = s.writeOperation(query)
 			if err != nil {
+				log.WithFields(log.Fields{"sql": query, "error": err}).Error("Error after call to 'writeOperation'")
 				errs <- err
 				return
 			}


### PR DESCRIPTION
#### What's new
- fixed a bug where failure counts in a status could be more than the total count
- added logging
- updated todo with tech debt: the error counts found when writing are used to figure out how many objects failed, but it's stupid and will not report an accurate failure account...gross

#### How to test
`make test`