### PR TITLE
'Accept' Header by default

### DIFF
--- a/http/api_root.go
+++ b/http/api_root.go
@@ -25,11 +25,6 @@ func (h APIRootHandler) Delete(w http.ResponseWriter, r *http.Request) {
 func (h APIRootHandler) Get(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"handler": "APIRootHandler"}).Debug("Handler called")
 
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
-
 	path := trimSlashes(r.URL.Path)
 
 	apiRoot, err := h.APIRootService.APIRoot(r.Context(), path)

--- a/http/api_root_test.go
+++ b/http/api_root_test.go
@@ -100,17 +100,6 @@ func TestAPIRootHandlerGetNoAPIRoot(t *testing.T) {
 	}
 }
 
-func TestAPIRootHandlerGetNotAcceptable(t *testing.T) {
-	h := APIRootHandler{APIRootService: mockAPIRootService()}
-	req := newClientRequest(http.MethodGet, testAPIRootURL, nil)
-	req.Header.Set("Accept", "invalid")
-	status, _, _ := callHandler(h.Get, req)
-
-	if status != http.StatusNotAcceptable {
-		t.Error("Got:", status, "Expected:", http.StatusNotAcceptable)
-	}
-}
-
 func TestAPIRootHandlerPost(t *testing.T) {
 	h := APIRootHandler{APIRootService: mockAPIRootService()}
 	status, _ := handlerTest(h.Post, http.MethodPost, testAPIRootURL, nil)

--- a/http/collection.go
+++ b/http/collection.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/pladdy/cabby"
@@ -25,11 +24,6 @@ func (h CollectionHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // Get handles a get request
 func (h CollectionHandler) Get(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"handler": "CollectionHandler"}).Debug("Handler called")
-
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
 
 	if !requestIsReadAuthorized(r) {
 		forbidden(w, errors.New("Unauthorized access"))

--- a/http/collection_test.go
+++ b/http/collection_test.go
@@ -110,17 +110,6 @@ func TestCollectionHandlerGetNoCollection(t *testing.T) {
 	}
 }
 
-func TestCollectionHandlerGetNotAcceptable(t *testing.T) {
-	h := CollectionHandler{CollectionService: mockCollectionService()}
-	req := newClientRequest(http.MethodGet, testCollectionURL, nil)
-	req.Header.Set("Accept", "invalid")
-	status, _, _ := callHandler(h.Get, req)
-
-	if status != http.StatusNotAcceptable {
-		t.Error("Got:", status, "Expected:", http.StatusNotAcceptable)
-	}
-}
-
 func TestCollectionHandlerPost(t *testing.T) {
 	h := CollectionHandler{CollectionService: mockCollectionService()}
 	status, _ := handlerTest(h.Post, http.MethodPost, testCollectionURL, nil)

--- a/http/discovery.go
+++ b/http/discovery.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -28,11 +27,6 @@ func (h DiscoveryHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // Get serves a discovery resource
 func (h DiscoveryHandler) Get(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"handler": "DiscoveryHandler"}).Debug("Handler called")
-
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
 
 	discovery, err := h.DiscoveryService.Discovery(r.Context())
 	if err != nil {

--- a/http/discovery_test.go
+++ b/http/discovery_test.go
@@ -102,17 +102,6 @@ func TestDiscoveryHandlerGetNoDiscovery(t *testing.T) {
 	}
 }
 
-func TestDiscoveryHandlerGetNotAcceptable(t *testing.T) {
-	h := DiscoveryHandler{DiscoveryService: mockDiscoveryService()}
-	req := newClientRequest(http.MethodGet, testDiscoveryURL, nil)
-	req.Header.Set("Accept", "invalid")
-	status, _, _ := callHandler(h.Get, req)
-
-	if status != http.StatusNotAcceptable {
-		t.Error("Got:", status, "Expected:", http.StatusNotAcceptable)
-	}
-}
-
 func TestDiscoveryHandlerPost(t *testing.T) {
 	ds := mockDiscoveryService()
 	ds.DiscoveryFn = func(ctx context.Context) (cabby.Discovery, error) {

--- a/http/manifest.go
+++ b/http/manifest.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/pladdy/cabby"
@@ -25,11 +24,6 @@ func (h ManifestHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // Get serves a manifest resource
 func (h ManifestHandler) Get(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"handler": "ManifestHandler"}).Debug("Handler called")
-
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
 
 	if !requestIsReadAuthorized(r) {
 		forbidden(w, errors.New("Unauthorized access"))

--- a/http/manifest_test.go
+++ b/http/manifest_test.go
@@ -98,17 +98,6 @@ func TestManifestHandlerGetHeaders(t *testing.T) {
 	}
 }
 
-func TestManifestHandlerGetNotAcceptable(t *testing.T) {
-	h := ManifestHandler{ManifestService: mockManifestService()}
-	req := newClientRequest(http.MethodGet, testManifestURL, nil)
-	req.Header.Set("Accept", "invalid")
-	status, _, _ := callHandler(h.Get, req)
-
-	if status != http.StatusNotAcceptable {
-		t.Error("Got:", status, "Expected:", http.StatusNotAcceptable)
-	}
-}
-
 func TestManifestHandlerGetInternalServerError(t *testing.T) {
 	expected := cabby.Error{
 		Title: "Internal Server Error", Description: "Manifest failure", HTTPStatus: http.StatusInternalServerError}

--- a/http/object.go
+++ b/http/object.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/pladdy/cabby"
@@ -37,11 +36,6 @@ func (h ObjectHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // Get handles a get request for the objects endpoint
 func (h ObjectHandler) Get(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"handler": "ObjectHandler", "objectID": takeObjectID(r)}).Debug("Handler called")
-
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
 
 	if !requestIsReadAuthorized(r) {
 		forbidden(w, errors.New("Unauthorized access"))

--- a/http/object_test.go
+++ b/http/object_test.go
@@ -110,19 +110,6 @@ func TestObjectHandlerGetForbidden(t *testing.T) {
 	}
 }
 
-func TestObjectHandlerGetNotAcceptable(t *testing.T) {
-	h := ObjectHandler{ObjectService: mockObjectService()}
-
-	// call handler for object
-	req := newClientRequest(http.MethodGet, testObjectURL, nil)
-	req.Header.Set("Accept", "invalid")
-	status, _, _ := callHandler(h.Get, req)
-
-	if status != http.StatusNotAcceptable {
-		t.Error("Got:", status, "Expected:", http.StatusNotAcceptable)
-	}
-}
-
 func TestObjectHandlerGetInternalServerError(t *testing.T) {
 	expected := cabby.Error{
 		Title: "Internal Server Error", Description: "Object failure", HTTPStatus: http.StatusInternalServerError}

--- a/http/objects.go
+++ b/http/objects.go
@@ -30,11 +30,6 @@ func (h ObjectsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 func (h ObjectsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"handler": "ObjectsHandler"}).Debug("Handler called")
 
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
-
 	if !requestIsReadAuthorized(r) {
 		forbidden(w, errors.New("Unauthorized access"))
 		return
@@ -107,11 +102,6 @@ func (h ObjectsHandler) Post(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ObjectsHandler) validPost(w http.ResponseWriter, r *http.Request) (isValid bool) {
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
-
 	if !verifyRequestHeader(r, "Content-Type", cabby.TaxiiContentType) {
 		unsupportedMediaType(w, fmt.Errorf("Content-Type header must be '%v'", cabby.TaxiiContentType))
 		return

--- a/http/objects_test.go
+++ b/http/objects_test.go
@@ -186,19 +186,6 @@ func TestObjectsHandlerGetNoObjects(t *testing.T) {
 	}
 }
 
-func TestObjectsHandlerGetNotAcceptable(t *testing.T) {
-	h := ObjectsHandler{ObjectService: mockObjectService()}
-
-	// call handler for object
-	req := newClientRequest(http.MethodGet, testObjectURL, nil)
-	req.Header.Set("Accept", "invalid")
-	status, _, _ := callHandler(h.Get, req)
-
-	if status != http.StatusNotAcceptable {
-		t.Error("Got:", status, "Expected:", http.StatusNotAcceptable)
-	}
-}
-
 func TestObjectsHandlerGetPage(t *testing.T) {
 	tests := []struct {
 		limit    int
@@ -381,7 +368,6 @@ func TestValidPost(t *testing.T) {
 		valid       bool
 	}{
 		{cabby.TaxiiContentType, cabby.TaxiiContentType, true},
-		{"invalid", cabby.TaxiiContentType, false},
 		{cabby.TaxiiContentType, "invalid", false},
 	}
 

--- a/http/routes.go
+++ b/http/routes.go
@@ -26,13 +26,13 @@ func registerAPIRoots(ds cabby.DataStore, sm *http.ServeMux) {
 
 func registerAPIRoot(ah APIRootHandler, path string, sm *http.ServeMux) {
 	if path != "" {
-		registerRoute(sm, path, WithAcceptSet(routeHandler(ah), cabby.TaxiiContentType))
+		registerRoute(sm, path, routeHandler(ah))
 	}
 }
 
 func registerCollectionRoutes(ds cabby.DataStore, apiRoot cabby.APIRoot, sm *http.ServeMux) {
 	csh := CollectionsHandler{CollectionService: ds.CollectionService()}
-	registerRoute(sm, apiRoot.Path+"/collections", WithAcceptSet(routeHandler(csh), cabby.TaxiiContentType))
+	registerRoute(sm, apiRoot.Path+"/collections", routeHandler(csh))
 
 	ss := ds.StatusService()
 	osh := ObjectsHandler{
@@ -54,7 +54,7 @@ func registerCollectionRoutes(ds cabby.DataStore, apiRoot cabby.APIRoot, sm *htt
 		registerRoute(
 			sm,
 			apiRoot.Path+"/collections/"+collectionID.String(),
-			WithAcceptSet(routeHandler(ch), cabby.TaxiiContentType))
+			routeHandler(ch))
 		registerRoute(
 			sm,
 			apiRoot.Path+"/collections/"+collectionID.String()+"/objects",
@@ -62,11 +62,11 @@ func registerCollectionRoutes(ds cabby.DataStore, apiRoot cabby.APIRoot, sm *htt
 		registerRoute(
 			sm,
 			apiRoot.Path+"/collections/"+collectionID.String()+"/manifest",
-			WithAcceptSet(routeHandler(mh), cabby.TaxiiContentType))
+			routeHandler(mh))
 	}
 
 	sh := StatusHandler{StatusService: ss}
-	registerRoute(sm, apiRoot.Path+"/status", WithAcceptSet(routeHandler(sh), cabby.TaxiiContentType))
+	registerRoute(sm, apiRoot.Path+"/status", routeHandler(sh))
 }
 
 func registerRoute(sm *http.ServeMux, path string, h http.HandlerFunc) {

--- a/http/server.go
+++ b/http/server.go
@@ -16,7 +16,7 @@ func NewCabby(ds cabby.DataStore, c cabby.Config) *http.Server {
 	registerAPIRoots(ds, handler)
 
 	dh := DiscoveryHandler{DiscoveryService: ds.DiscoveryService(), Port: c.Port}
-	registerRoute(handler, "taxii2", WithAcceptSet(routeHandler(dh), cabby.TaxiiContentType))
+	registerRoute(handler, "taxii2", routeHandler(dh))
 	registerRoute(handler, "/", handleUndefinedRoute)
 
 	return setupServer(ds, handler, c)
@@ -27,8 +27,9 @@ func setupServer(ds cabby.DataStore, h http.Handler, c cabby.Config) *http.Serve
 	log.WithFields(log.Fields{"port": p}).Info("Server port configured")
 
 	return &http.Server{
-		Addr:         ":" + p,
-		Handler:      withBasicAuth(withLogging(h), ds.UserService()),
+		Addr: ":" + p,
+		// Wrap the server handler with logging, then basicAuth, then an 'Accept' header check
+		Handler:      withAcceptSet(withBasicAuth(withLogging(h), ds.UserService()), cabby.TaxiiContentType),
 		TLSConfig:    setupTLS(),
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}

--- a/http/server.go
+++ b/http/server.go
@@ -29,7 +29,9 @@ func setupServer(ds cabby.DataStore, h http.Handler, c cabby.Config) *http.Serve
 	return &http.Server{
 		Addr: ":" + p,
 		// Wrap the server handler with logging, then basicAuth, then an 'Accept' header check
-		Handler:      withAcceptSet(withBasicAuth(withLogging(h), ds.UserService()), cabby.TaxiiContentType),
+		Handler: withAcceptSet(
+			withBasicAuth(withLogging(h), ds.UserService()),
+			cabby.TaxiiContentType),
 		TLSConfig:    setupTLS(),
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 	}

--- a/http/versions.go
+++ b/http/versions.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/pladdy/cabby"
@@ -25,11 +24,6 @@ func (h VersionsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // Get serves a Versions resource
 func (h VersionsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"handler": "VersionsHandler"}).Debug("Handler called")
-
-	if !verifyRequestHeader(r, "Accept", cabby.TaxiiContentType) {
-		notAcceptable(w, fmt.Errorf("Accept header must be '%v'", cabby.TaxiiContentType))
-		return
-	}
 
 	if !requestIsReadAuthorized(r) {
 		forbidden(w, errors.New("Unauthorized access"))

--- a/http/versions_test.go
+++ b/http/versions_test.go
@@ -74,17 +74,6 @@ func TestVersionsHandlerGetHeaders(t *testing.T) {
 	}
 }
 
-func TestVersionsHandlerGetInvalidAccept(t *testing.T) {
-	h := VersionsHandler{VersionsService: mockVersionsService()}
-	req := newClientRequest(http.MethodGet, testVersionsURL, nil)
-	req.Header.Set("Accept", "invalid")
-	status, _, _ := callHandler(h.Get, req)
-
-	if status != http.StatusNotAcceptable {
-		t.Error("Got:", status, "Expected:", http.StatusNotAcceptable)
-	}
-}
-
 func TestVersionsHandlerGetInvalidPage(t *testing.T) {
 	h := VersionsHandler{VersionsService: mockVersionsService()}
 	req := newClientRequest(http.MethodGet, testVersionsURL+"?limit=0", nil)


### PR DESCRIPTION
#### What's new
- 'Accept' header has to be a TAXII content type on all handlers
- move the logic to the Handle interface so it's on all routes by default
- remove tests on handlers and only test

Since basic auth is handled by default on all handlers, i figured why not do the same with accepting the TAXII type.

#### How to test
`make test`